### PR TITLE
Handling empty command without arguments.

### DIFF
--- a/bootstrap_py/commands.py
+++ b/bootstrap_py/commands.py
@@ -74,7 +74,7 @@ def parse_options(metadata):
     parser = argparse.ArgumentParser(description='%(prog)s usage:',
                                      prog=__prog__)
     setoption(parser, metadata=metadata)
-    return parser.parse_args()
+    return parser
 
 
 def main():
@@ -84,7 +84,12 @@ def main():
         if pkg_version.updatable():
             pkg_version.show_message()
         metadata = control.retreive_metadata()
-        args = parse_options(metadata)
+        parser = parse_options(metadata)
+        argvs = sys.argv
+        if len(argvs) <= 1:
+            parser.print_help()
+            sys.exit(1)
+        args = parser.parse_args()
         control.print_licences(args, metadata)
         control.check_repository_existence(args)
         control.check_package_existence(args)

--- a/bootstrap_py/tests/test_commands.py
+++ b/bootstrap_py/tests/test_commands.py
@@ -46,7 +46,8 @@ class CommandsTests(unittest.TestCase):
     def test_parse_options_fail(self):
         """fail parse options."""
         with self.assertRaises(SystemExit) as exc:
-            commands.parse_options(self.metadata)
+            parser = commands.parse_options(self.metadata)
+            parser.parse_args()
         self.assertEqual(2, exc.exception.code)
         self.assertTrue(sys.stderr.getvalue())
 


### PR DESCRIPTION
Thanks for the tool.
This PR is the fix for below specified glitch.
```
(venv) plasmashadows-MacBook-Pro:side plasmashadow$ bootstrap-py
Traceback (most recent call last):
  File "/Users/plasmashadow/side/venv/bin/bootstrap-py", line 11, in <module>
    sys.exit(main())
  File "/Users/plasmashadow/side/venv/lib/python3.6/site-packages/bootstrap_py/commands.py", line 89, in main
    control.check_repository_existence(args)
  File "/Users/plasmashadow/side/venv/lib/python3.6/site-packages/bootstrap_py/control.py", line 44, in check_repository_existence
    repodir = os.path.join(params.outdir, params.name)
AttributeError: 'Namespace' object has no attribute 'outdir'
```